### PR TITLE
added support for multiple providers

### DIFF
--- a/example/server/src/middleware/oauth.ts
+++ b/example/server/src/middleware/oauth.ts
@@ -1,5 +1,5 @@
-import oauthService, { IdTokenPayload } from "@/services/oauth.js";
 import { Request, Response, NextFunction } from "express";
+import oauthService, { IdTokenPayload } from "@/services/oauth.js";
 
 type OAuthSuccessCallback = {
   req: Request;
@@ -13,25 +13,52 @@ type OAuthFailureCallback = {
   error: Error;
 };
 
-const GoogleOAuth = (
-  onSuccess: (successCallback: OAuthSuccessCallback) => void | Promise<void>,
-  onFailure: (errorCallback: OAuthFailureCallback) => void
-) => {
-  return (req: Request, res: Response, next: NextFunction) => {
-    const requiredFields = ["code", "client_id", "redirect_uri", "grant_type"];
-    for (const field of requiredFields) {
-      if (!req.body[field] || typeof req.body[field] !== "string") {
-        const error = new Error(`Missing field: ${field}`);
-        return onFailure({ req, res, error });
-      }
-    }
-
-    const { code, grant_type, redirect_uri, client_id } = req.body;
-    oauthService
-      .exchangeCode(code, grant_type, client_id, redirect_uri)
-      .then(data => onSuccess({ req, res, data: data as IdTokenPayload }))
-      .catch(err => onFailure({ req, res, error: err as Error }))
-      .finally(() => next);
-  };
+type Provider = {
+  onSuccess: (successCallback: OAuthSuccessCallback) => void | Promise<void>;
+  onFailure: (errorCallback: OAuthFailureCallback) => void;
+  clientSecret: string;
+  baseUrl: string;
 };
-export default GoogleOAuth;
+
+class OAuth {
+  private _providers: Record<string, Provider>;
+
+  constructor() {
+    this._providers = {};
+  }
+
+  setupProvider(provider: string, { baseUrl, clientSecret, onSuccess, onFailure }: Provider) {
+    this._providers[provider] = {
+      baseUrl,
+      clientSecret,
+      onSuccess,
+      onFailure,
+    };
+  }
+
+  authenticate(provider: string) {
+    if (!this._providers[provider]) {
+      throw new Error(`Provider ${provider} has not been set`);
+    }
+    const { onSuccess, onFailure, clientSecret, baseUrl } = this._providers[provider];
+
+    return (req: Request, res: Response, next: NextFunction) => {
+      const requiredFields = ["code", "client_id", "redirect_uri", "grant_type"];
+      for (const field of requiredFields) {
+        if (!req.body[field] || typeof req.body[field] !== "string") {
+          const error = new Error(`Missing field: ${field}`);
+          return onFailure({ req, res, error });
+        }
+      }
+
+      const { code, grant_type, redirect_uri, client_id } = req.body;
+      oauthService
+        .exchangeCode(baseUrl, code, grant_type, client_id, redirect_uri, clientSecret)
+        .then(data => onSuccess({ req, res, data: data as IdTokenPayload }))
+        .catch(err => onFailure({ req, res, error: err as Error }))
+        .finally(() => next);
+    };
+  }
+}
+
+export default OAuth;

--- a/example/server/src/routers/oauth-router.ts
+++ b/example/server/src/routers/oauth-router.ts
@@ -1,16 +1,19 @@
-import GoogleOAuth from "@/middleware/oauth.js";
 import { Router } from "express";
+import OAuth from "../middleware/oauth.js";
 
 export const oauthRouter = Router();
 
-oauthRouter.post(
-  "/exchange",
-  GoogleOAuth(
-    ({ res, data }) => {
-      res.status(200).json(data);
-    },
-    ({ res, error }) => {
-      res.status(500).json({ error: error.message });
-    }
-  )
-);
+const googleClientSecret = process.env["GOOGLE_CLIENT_SECRET"] as string;
+const oauth = new OAuth();
+oauth.setupProvider("google", {
+  baseUrl: "https://oauth2.googleapis.com/token",
+  clientSecret: googleClientSecret,
+  onSuccess: ({ res, data }) => {
+    res.status(200).json(data);
+  },
+  onFailure: ({ res, error }) => {
+    res.status(500).json({ error: error.message });
+  },
+});
+
+oauthRouter.post("/exchange", oauth.authenticate("google"));

--- a/example/server/src/services/oauth.ts
+++ b/example/server/src/services/oauth.ts
@@ -29,20 +29,20 @@ export interface IdTokenPayload {
   exp: number;
 }
 
-const googleClientSecret = process.env["GOOGLE_CLIENT_SECRET"] as string;
-
 const exchangeCode = async (
+  baseUrl: string,
   code: string,
   grantType: string,
   clientId: string,
-  redirectUri: string
+  redirectUri: string,
+  clientSecret: string
 ): Promise<IdTokenPayload | Error> => {
-  const url = new URL("https://oauth2.googleapis.com/token");
+  const url = new URL(baseUrl);
   url.searchParams.set("grant_type", grantType);
   url.searchParams.set("code", code);
   url.searchParams.set("client_id", clientId);
   url.searchParams.set("redirect_uri", redirectUri);
-  url.searchParams.set("client_secret", googleClientSecret);
+  url.searchParams.set("client_secret", clientSecret);
 
   try {
     const res = await fetch(url, { method: "POST" });


### PR DESCRIPTION
* Created OAuth object which can hold multiple providers by using setupProvider and calling [authenticate](https://github.com/lesterfernandez/oauth2-ts/blob/oauth-object/example/server/src/routers/oauth-router.ts#L8)

It is still missing a way for the object set up by the developer to be passed down between different routes as some sort of global variable (probably using a [module](https://stackoverflow.com/questions/1479319/simplest-cleanest-way-to-implement-a-singleton-in-javascript))